### PR TITLE
Remove tau_mem as a parameter from IAF

### DIFF
--- a/sinabs/layers/iaf.py
+++ b/sinabs/layers/iaf.py
@@ -5,7 +5,6 @@ from sinabs.activation import MultiSpike, MembraneSubtract, SingleExponential
 from .reshape import SqueezeMixin
 from .lif import LIF, LIFRecurrent
 import numpy as np
-from functools import cached_property
 
 
 class IAF(LIF):
@@ -71,7 +70,7 @@ class IAF(LIF):
         # IAF does not have time constants
         self.tau_mem = None
 
-    @cached_property
+    @property
     def alpha_mem_calculated(self):
         return torch.tensor(1.)
 

--- a/sinabs/layers/iaf.py
+++ b/sinabs/layers/iaf.py
@@ -5,6 +5,7 @@ from sinabs.activation import MultiSpike, MembraneSubtract, SingleExponential
 from .reshape import SqueezeMixin
 from .lif import LIF, LIFRecurrent
 import numpy as np
+from functools import cached_property
 
 
 class IAF(LIF):
@@ -67,8 +68,12 @@ class IAF(LIF):
             norm_input=False,
             record_states=record_states,
         )
-        # deactivate tau_mem being learned
-        self.tau_mem.requires_grad = False
+        # IAF does not have time constants
+        self.tau_mem = None
+
+    @cached_property
+    def alpha_mem_calculated(self):
+        return torch.tensor(1.)
 
     @property
     def _param_dict(self) -> dict:

--- a/tests/test_iaf.py
+++ b/tests/test_iaf.py
@@ -16,6 +16,7 @@ def test_iaf_basic():
     assert input_current.shape == spike_output.shape
     assert torch.isnan(spike_output).sum() == 0
     assert spike_output.sum() > 0
+    assert 'tau_mem' not in dict(layer.named_parameters()).keys()
 
 
 def test_iaf_v_mem_recordings():


### PR DESCRIPTION
this removes tau_mem from IAF layers completely. We define and fix alpha_mem as 1, which is used in the computation under the hood. Speed benchmarking with @sheiksadique comparing current implementation as LIF child class against a separate implementation of IAF has not shown significant performance hit. For the purpose of code reuse and readibility, I'm proposing to keep the current structure for now.