### PR TITLE
Calculate tau from alpha. Don't move to other device for conversion

### DIFF
--- a/sinabs/layers/lif.py
+++ b/sinabs/layers/lif.py
@@ -127,7 +127,7 @@ class LIF(StatefulLayer):
             if self.alpha_syn is None:
                 return None
             else:
-                return - 1.0 / torch.log(self.alpha_mem)
+                return - 1.0 / torch.log(self.alpha_syn)
         else:
             return self.tau_syn
 

--- a/sinabs/layers/lif.py
+++ b/sinabs/layers/lif.py
@@ -99,18 +99,37 @@ class LIF(StatefulLayer):
         if self.train_alphas:
             return self.alpha_mem
         else:
-            # we're going to always calculate this alpha parameter on CPU for 64 bit floating point precision
-            original_device = self.tau_mem.device
-            return torch.exp(-1.0 / self.tau_mem.to("cpu")).to(original_device)
+            return torch.exp(-1.0 / self.tau_mem)
 
     @property
     def alpha_syn_calculated(self):
         if self.train_alphas:
             return self.alpha_syn
-        if not self.train_alphas and self.tau_syn:
-            return torch.exp(-1 / self.tau_syn)
+        elif self.tau_syn:
+            # Calculate alpha with 64 bit floating point precision
+            return torch.exp(-1.0 / self.tau_syn)
         else:
             return None
+
+    @property
+    def tau_mem_calculated(self):
+        if self.train_alphas:
+            if self.alpha_mem is None:
+                return None
+            else:
+                return - 1.0 / torch.log(self.alpha_mem)
+        else:
+            return self.tau_mem
+
+    @property
+    def tau_syn_calculated(self):
+        if self.train_alphas:
+            if self.alpha_syn is None:
+                return None
+            else:
+                return - 1.0 / torch.log(self.alpha_mem)
+        else:
+            return self.tau_syn
 
     def forward(self, input_data: torch.Tensor):
         """

--- a/sinabs/layers/lif.py
+++ b/sinabs/layers/lif.py
@@ -184,13 +184,13 @@ class LIF(StatefulLayer):
     @property
     def _param_dict(self) -> dict:
         param_dict = super()._param_dict
+        tau_syn = self.tau_syn_calculated
+        if tau_syn is not None:
+            tau_syn = tau_syn.detach()
+
         param_dict.update(
-            tau_mem=-1 / torch.log(self.alpha_mem.detach_())
-            if self.train_alphas
-            else self.tau_mem,
-            tau_syn=-1 / torch.log(self.alpha_syn.detach_())
-            if self.train_alphas
-            else self.tau_syn,
+            tau_mem=self.tau_mem_calculated.detach(),
+            tau_syn=tau_syn,
             spike_threshold=self.spike_threshold,
             spike_fn=self.spike_fn,
             reset_fn=self.reset_fn,

--- a/tests/test_lif.py
+++ b/tests/test_lif.py
@@ -1,3 +1,4 @@
+from itertools import product
 import torch
 import torch.nn as nn
 from sinabs.layers import LIF, LIFRecurrent
@@ -298,3 +299,22 @@ def test_min_v_mem():
     layer = LIF(tau_mem=tau_mem, min_v_mem=-0.5)
     layer(input_data)
     assert not (layer.v_mem < -0.5).any()
+
+
+params = product((20., None), (True, False))
+@pytest.mark.parametrize("tau_syn,train_alphas", params)
+def test_alpha_tau_conversion(tau_syn, train_alphas):
+    tau_mem = torch.rand((3, 4)) * 20 + 30
+    alpha_mem = torch.exp(-1.0 / tau_mem)
+
+    layer = LIF(tau_mem=tau_mem, tau_syn=tau_syn, train_alphas=train_alphas)
+    assert torch.isclose(layer.tau_mem_calculated, tau_mem).all()
+    assert torch.isclose(layer.alpha_mem_calculated, alpha_mem).all()
+    if tau_syn is None:
+        assert layer.tau_syn_calculated is None
+        assert layer.alpha_syn_calculated is None
+    else:
+        tau_syn = torch.as_tensor(tau_syn)
+        alpha_syn = torch.exp(-1.0 / tau_syn)
+        assert torch.isclose(layer.tau_syn_calculated, tau_syn).all()
+        assert torch.isclose(layer.alpha_syn_calculated, alpha_syn).all()

--- a/tests/test_lif.py
+++ b/tests/test_lif.py
@@ -16,6 +16,9 @@ def test_lif_basic():
     layer = LIF(tau_mem=tau_mem)
     spike_output = layer(input_current)
 
+    # Make sure __repr__ works
+    repr(layer)
+
     assert layer.does_spike
     assert input_current.shape == spike_output.shape
     assert torch.isnan(spike_output).sum() == 0


### PR DESCRIPTION
This PR includes 2 smaller changes to the `LIF` class:

1. Properties `tau_mem_calculated` and `tau_syn_calculated` have been added, to return synaptic/membrane time constants, either as they are or, if `self.train_alphas`, as calculated from the corresponding alpha parameters. This is analogous to `alpha_mem/syn_calculated` .

2. Tau and alpha parameters are not moved to CPU and back anymore for conversion, because it turned out to have no effect.