### PR TITLE
Prevent in-place updates of already recorded state

### DIFF
--- a/sinabs/layers/functional/lif.py
+++ b/sinabs/layers/functional/lif.py
@@ -59,7 +59,9 @@ def lif_forward(
     state_names = list(state.keys())
 
     output_spikes = []
-    recordings = []
+    if record_states:
+        recordings = {name: [] for name in state_names}
+
     for step in range(n_time_steps):
         spikes, state = lif_forward_single(
             input_data=input_data[:, step],
@@ -75,14 +77,14 @@ def lif_forward(
         )
         output_spikes.append(spikes)
         if record_states:
-            recordings.append(state)
+            for name in state_names:
+                recordings[name].append(state[name].detach().clone())
 
-    record_dict = {}
     if record_states:
-        for state_name in state_names:
-            record_dict[state_name] = torch.stack(
-                [item[state_name].detach() for item in recordings], 1
-            )
+        record_dict = {name: torch.stack(vals, 1) for name, vals in recordings.items()}
+    else:
+        record_dict = dict()
+
     return torch.stack(output_spikes, 1), state, record_dict
 
 

--- a/tests/test_lif.py
+++ b/tests/test_lif.py
@@ -28,10 +28,13 @@ def test_lif_basic():
 def test_lif_v_mem_recordings():
     batch_size, time_steps = 10, 100
     input_current = torch.rand(batch_size, time_steps, 2, 7, 7)
+    input_current[:, :5] = 0
     layer = LIF(tau_mem=20.0, norm_input=False, record_states=True)
     spike_output = layer(input_current)
 
     assert layer.recordings["v_mem"].shape == spike_output.shape
+    # Ensure causality
+    assert (layer.recordings["v_mem"][:, :5] == 0).all()
     assert not layer.recordings["v_mem"].requires_grad
     assert "i_syn" not in layer.recordings.keys()
 


### PR DESCRIPTION
This addresses an issue when recording states in the `lif_forward` function:
Until now, the current state was stored in a list of recorded states. However, the same object was passed to the next evolution step and changed in-place, affecting also the previously recorded state. Therefore the recordings were not as expected.

This PR fixes this issue and extends a unit test.