### PR TITLE
Allow backpropagating through recorded states.

### DIFF
--- a/sinabs/layers/functional/alif.py
+++ b/sinabs/layers/functional/alif.py
@@ -92,7 +92,7 @@ def alif_forward(
     if record_states:
         for state_name in state_names:
             record_dict[state_name] = torch.stack(
-                [item[state_name].detach() for item in recordings], 1
+                [item[state_name] for item in recordings], 1
             )
     return torch.stack(output_spikes, 1), state, record_dict
 
@@ -147,6 +147,6 @@ def alif_recurrent(
     if record_states:
         for state_name in state_names:
             record_dict[state_name] = torch.stack(
-                [item[state_name].detach() for item in recordings], 1
+                [item[state_name] for item in recordings], 1
             )
     return torch.stack(output_spikes, 1), state, record_dict

--- a/sinabs/layers/functional/lif.py
+++ b/sinabs/layers/functional/lif.py
@@ -81,7 +81,7 @@ def lif_forward(
         output_spikes.append(spikes)
         if record_states:
             for name in state_names:
-                recordings[name].append(state[name].detach().clone())
+                recordings[name].append(state[name].clone())
 
     if record_states:
         record_dict = {name: torch.stack(vals, 1) for name, vals in recordings.items()}
@@ -137,6 +137,6 @@ def lif_recurrent(
     if record_states:
         for state_name in state_names:
             record_dict[state_name] = torch.stack(
-                [item[state_name].detach() for item in recordings], 1
+                [item[state_name] for item in recordings], 1
             )
     return torch.stack(output_spikes, 1), state, record_dict

--- a/tests/test_alif.py
+++ b/tests/test_alif.py
@@ -150,10 +150,11 @@ def test_alif_v_mem_recordings():
     layer = ALIF(tau_mem=20.0, tau_adapt=10.0, norm_input=False, record_states=True)
     spike_output = layer(input_current)
 
+    layer.recordings["v_mem"].sum().backward()
+    assert layer.tau_mem.grad is not None
+
     assert layer.recordings["v_mem"].shape == spike_output.shape
-    assert not layer.recordings["v_mem"].requires_grad
     assert layer.recordings["spike_threshold"].shape == spike_output.shape
-    assert not layer.recordings["spike_threshold"].requires_grad
     assert "i_syn" not in layer.recordings.keys()
 
 
@@ -165,10 +166,12 @@ def test_alif_i_syn_recordings():
     )
     spike_output = layer(input_current)
 
+    layer.recordings["i_syn"].sum().backward()
+    assert layer.tau_syn.grad is not None
+    assert layer.tau_mem.grad is None
+
     assert layer.recordings["v_mem"].shape == spike_output.shape
     assert layer.recordings["i_syn"].shape == spike_output.shape
-    assert not layer.recordings["v_mem"].requires_grad
-    assert not layer.recordings["i_syn"].requires_grad
 
 
 def test_alif_recurrent_v_mem_recordings():
@@ -186,8 +189,10 @@ def test_alif_recurrent_v_mem_recordings():
     )
     spike_output = layer(input_current)
 
+    layer.recordings["v_mem"].sum().backward()
+    assert layer.tau_mem.grad is not None
+
     assert layer.recordings["v_mem"].shape == spike_output.shape
-    assert not layer.recordings["v_mem"].requires_grad
     assert "i_syn" not in layer.recordings.keys()
 
 
@@ -207,10 +212,11 @@ def test_alif_recurrent_i_syn_recordings():
     )
     spike_output = layer(input_current)
 
+    layer.recordings["i_syn"].sum().backward()
+    assert layer.tau_syn.grad is not None
+
     assert layer.recordings["v_mem"].shape == spike_output.shape
     assert layer.recordings["i_syn"].shape == spike_output.shape
-    assert not layer.recordings["v_mem"].requires_grad
-    assert not layer.recordings["i_syn"].requires_grad
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")

--- a/tests/test_exp_leak.py
+++ b/tests/test_exp_leak.py
@@ -60,6 +60,8 @@ def test_leaky_v_mem_recordings():
     layer = ExpLeak(tau_mem=30.0, record_states=True)
     membrane_output = layer(input_current)
 
+    layer.recordings["v_mem"].sum().backward()
+    assert layer.tau_mem.grad is not None
+
     assert layer.recordings["v_mem"].shape == membrane_output.shape
-    assert not layer.recordings["v_mem"].requires_grad
     assert "i_syn" not in layer.recordings.keys()

--- a/tests/test_iaf.py
+++ b/tests/test_iaf.py
@@ -27,7 +27,6 @@ def test_iaf_v_mem_recordings():
     spike_output = layer(input_current)
 
     assert layer.recordings["v_mem"].shape == spike_output.shape
-    assert not layer.recordings["v_mem"].requires_grad
     assert "i_syn" not in layer.recordings.keys()
 
 
@@ -37,10 +36,10 @@ def test_iaf_i_syn_recordings():
     layer = IAF(tau_syn=10.0, record_states=True)
     spike_output = layer(input_current)
 
+    layer.recordings["i_syn"].sum().backward()
+
     assert layer.recordings["v_mem"].shape == spike_output.shape
     assert layer.recordings["i_syn"].shape == spike_output.shape
-    assert not layer.recordings["v_mem"].requires_grad
-    assert not layer.recordings["i_syn"].requires_grad
 
 
 def test_iaf_recurrent_v_mem_recordings():
@@ -52,8 +51,9 @@ def test_iaf_recurrent_v_mem_recordings():
     layer = IAFRecurrent(rec_connect=rec_connect, record_states=True)
     spike_output = layer(input_current)
 
+    layer.recordings["v_mem"].sum().backward()
+
     assert layer.recordings["v_mem"].shape == spike_output.shape
-    assert not layer.recordings["v_mem"].requires_grad
     assert "i_syn" not in layer.recordings.keys()
 
 
@@ -66,10 +66,10 @@ def test_iaf_recurrent_i_syn_recordings():
     layer = IAFRecurrent(tau_syn=10.0, rec_connect=rec_connect, record_states=True)
     spike_output = layer(input_current)
 
+    layer.recordings["i_syn"].sum().backward()
+
     assert layer.recordings["v_mem"].shape == spike_output.shape
     assert layer.recordings["i_syn"].shape == spike_output.shape
-    assert not layer.recordings["v_mem"].requires_grad
-    assert not layer.recordings["i_syn"].requires_grad
 
 
 def test_iaf_single_spike():

--- a/tests/test_lif.py
+++ b/tests/test_lif.py
@@ -53,10 +53,12 @@ def test_lif_v_mem_recordings():
     layer = LIF(tau_mem=20.0, norm_input=False, record_states=True)
     spike_output = layer(input_current)
 
+    layer.recordings["v_mem"].sum().backward()
+    assert layer.tau_mem.grad is not None
+
     assert layer.recordings["v_mem"].shape == spike_output.shape
     # Ensure causality
     assert (layer.recordings["v_mem"][:, :5] == 0).all()
-    assert not layer.recordings["v_mem"].requires_grad
     assert "i_syn" not in layer.recordings.keys()
 
 
@@ -66,10 +68,11 @@ def test_lif_i_syn_recordings():
     layer = LIF(tau_mem=20.0, tau_syn=10.0, norm_input=False, record_states=True)
     spike_output = layer(input_current)
 
+    layer.recordings["i_syn"].sum().backward()
+    assert layer.tau_syn.grad is not None
+
     assert layer.recordings["v_mem"].shape == spike_output.shape
     assert layer.recordings["i_syn"].shape == spike_output.shape
-    assert not layer.recordings["v_mem"].requires_grad
-    assert not layer.recordings["i_syn"].requires_grad
 
 
 def test_lif_recurrent_v_mem_recordings():
@@ -83,8 +86,10 @@ def test_lif_recurrent_v_mem_recordings():
     )
     spike_output = layer(input_current)
 
+    layer.recordings["v_mem"].sum().backward()
+    assert layer.tau_mem.grad is not None
+
     assert layer.recordings["v_mem"].shape == spike_output.shape
-    assert not layer.recordings["v_mem"].requires_grad
     assert "i_syn" not in layer.recordings.keys()
 
 
@@ -103,10 +108,11 @@ def test_lif_recurrent_i_syn_recordings():
     )
     spike_output = layer(input_current)
 
+    layer.recordings["i_syn"].sum().backward()
+    assert layer.tau_syn.grad is not None
+
     assert layer.recordings["v_mem"].shape == spike_output.shape
     assert layer.recordings["i_syn"].shape == spike_output.shape
-    assert not layer.recordings["v_mem"].requires_grad
-    assert not layer.recordings["i_syn"].requires_grad
 
 
 def test_lif_single_spike():


### PR DESCRIPTION
Backpropagation through the history of recorded states, such as v_mem and i_syn. Update unit tests accordingly. Addresses issue #66