### PR TITLE
Add tests for norm input

### DIFF
--- a/tests/test_lif.py
+++ b/tests/test_lif.py
@@ -297,7 +297,7 @@ def test_lif_norm_input_with_synapse(tau_syn):
     # Different tau_mem between 10 and 100
     tau_mem = (torch.rand(n_neurons) * 90) + 10
     input_current = torch.rand((batch_size, time_steps, n_neurons))
-    # Very high spike threshold
+    # Very high spike threshold to prevent model from spiking (we need pre-spike v_mem)
     spike_threshold = 1e6
 
     layer = LIF(


### PR DESCRIPTION
Addresses #41 . Please review.

For `ExpLeak`  and `LIF` classes the new tests make sure that the membrane potential is scaled correctly.
For `ExpLeak` it furthermore verifies that the area under the v_mem curve for a single input pulse adds up to 1, independent of the membrane time constant.