### PR TITLE
84 handling batch size mismatch sometimes crashes

### DIFF
--- a/sinabs/layers/stateful_layer.py
+++ b/sinabs/layers/stateful_layer.py
@@ -62,7 +62,7 @@ class StatefulLayer(torch.nn.Module):
                 New batch size.
         """
         for name, buffer in self.named_buffers():
-            indices = torch.randint(low=0, high=buffer.shape[0], size=(new_batch_size,))
+            indices = torch.randint(low=0, high=buffer.shape[0], size=(new_batch_size,)).to(buffer.device)
             new_buffer = torch.index_select(buffer, 0, indices) 
             self.register_buffer(name, new_buffer)
     


### PR DESCRIPTION
- Implemented the necessary change.
- Test that replicated the situation under which it crashed. 
 
Note that this is related to some weirdness in `pytorch` allocation on the GPU and even in the previous version it worked some of the time. It worked more consistently if the GPU VRAM utilization is low and it crashed more often if the GPU was close to being full. This ensures that it works all the time.