### PR TITLE
Correct test whether subtract value is None

### DIFF
--- a/sinabs/activation/reset_mechanism.py
+++ b/sinabs/activation/reset_mechanism.py
@@ -39,7 +39,7 @@ class MembraneSubtract:
 
     def __call__(self, spikes, state, threshold):
         new_state = state.copy()
-        if self.subtract_value:
+        if self.subtract_value is not None:
             new_state["v_mem"] = new_state["v_mem"] - spikes * self.subtract_value
         else:
             new_state["v_mem"] = new_state["v_mem"] - spikes * threshold

--- a/tests/test_activations.py
+++ b/tests/test_activations.py
@@ -22,6 +22,12 @@ from sinabs.activation import (
         ),
         (
             SingleSpike,
+            MembraneSubtract(subtract_value=torch.tensor([0.9, 1.1])),
+            torch.tensor([1.0, 0.0]),
+            torch.tensor([1.6, 0.3]),
+        ),
+        (
+            SingleSpike,
             MembraneReset(),
             torch.tensor([1.0, 0.0]),
             torch.tensor([0.0, 0.3]),


### PR DESCRIPTION
Minor fix that makes sure that `subtract_value` variable in `MembraneSubtract` reset function is correctly identified if `None`, and does not cause problems when `subtract_value` is a tensor.

Allowing for individual thresholds in sinabs-exodus (https://github.com/synsense/sinabs-exodus/issues/12) depends on this.