### PR TITLE
Update .readthedocs.yaml to account for new mandatory env variable

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,11 @@ version: 2
 sphinx:
   configuration: docs/conf.py
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 python:
   install:
     - requirements: tests/requirements.txt


### PR DESCRIPTION
variable build.os now mandatory for readthedocs config, see https://blog.readthedocs.com/use-build-os-config/