### PR TITLE
238 dynapcnn visualizer enable excluding spike count plot

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ CHANGES
 =======
 
 * Spike count plot in 'DynapcnnVisualizer' is optional 
+* `DynapcnnVisualizer` allows custom JIT filters to make readout predictions
 
 v2.0.0
 ------

--- a/sinabs/backend/dynapcnn/dynapcnn_visualizer.py
+++ b/sinabs/backend/dynapcnn/dynapcnn_visualizer.py
@@ -1,6 +1,6 @@
 import socket
 import warnings
-from typing import Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import samna
 
@@ -49,6 +49,7 @@ class DynapcnnVisualizer:
         feature_names: Optional[List[str]] = None,
         readout_images: Optional[List[str]] = None,
         feature_count: Optional[int] = None,
+        readout_node: Union[str, Callable] = "JitMajorityReadout",
         extra_arguments: Optional[Dict[str, Dict[str, any]]] = None,
     ):
         """Quick wrapper around Samna objects to get a basic dynapcnn visualizer.
@@ -98,6 +99,9 @@ class DynapcnnVisualizer:
                 If the `feature_names` and `readout_images` was passed, this is not needed. Otherwise this parameter
                 should be passed, so that the GUI knows how many lines should be drawn on the `Spike Count Plot` and
                 `Readout Layer Plot`.
+            readout_node: str or Callable
+                Can either be a string "JitMajorityReadout" or a callable that returns a samna JIT filter
+                to decide on the readout prediction. Function parameters can be defined freely.
             extra_arguments: Optional[Dict[str, Dict[str, any]]] (defaults to None)
                 Extra arguments that can be passed to individual plots. Available keys are:
                 - `spike_count`: Arguments that can be passed to `spike_count` plot.
@@ -135,6 +139,7 @@ class DynapcnnVisualizer:
         self.readout_default_return_value = readout_default_return_value
         self.readout_default_threshold_low = readout_default_threshold_low
         self.readout_default_threshold_high = readout_default_threshold_high
+        self.readout_node = readout_node
 
         # Power monitor components
         if power_monitor_number_of_items != 3 and power_monitor_number_of_items != 5:
@@ -518,19 +523,32 @@ class DynapcnnVisualizer:
 
         ## Readout node
         if "r" in self.gui_type:
-            (_, majority_readout_node, _) = self.streamer_graph.sequential(
-                [
-                    spike_collection_node,
-                    samna.graph.JitMajorityReadout(samna.ui.Event),
-                    streamer_node,
-                ]
-            )
-            majority_readout_node.set_feature_count(self.feature_count)
-            majority_readout_node.set_default_feature(self.readout_default_return_value)
-            majority_readout_node.set_threshold_low(self.readout_default_threshold_low)
-            majority_readout_node.set_threshold_high(
-                self.readout_default_threshold_high
-            )
+            if self.readout_node == "JitMajorityReadout":
+                (_, majority_readout_node, _) = self.streamer_graph.sequential(
+                    [
+                        spike_collection_node,
+                        samna.graph.JitMajorityReadout(samna.ui.Event),
+                        streamer_node,
+                    ]
+                )
+                majority_readout_node.set_feature_count(self.feature_count)
+                majority_readout_node.set_default_feature(
+                    self.readout_default_return_value
+                )
+                majority_readout_node.set_threshold_low(
+                    self.readout_default_threshold_low
+                )
+                majority_readout_node.set_threshold_high(
+                    self.readout_default_threshold_high
+                )
+            else:
+                (_, majority_readout_node, _) = self.streamer_graph.sequential(
+                    [
+                        spike_collection_node,
+                        self.readout_node,
+                        streamer_node,
+                    ]
+                )
 
         ## Readout layer visualization
         if "o" in self.gui_type:

--- a/sinabs/backend/dynapcnn/dynapcnn_visualizer.py
+++ b/sinabs/backend/dynapcnn/dynapcnn_visualizer.py
@@ -109,7 +109,7 @@ class DynapcnnVisualizer:
                 - `power_measurement`: Arguments that can be passed `power_measurement` plot.
         """
         # Checks if the configuration passed is valid
-        if add_readout_plot and not readout_images:
+        if add_readout_plot and readout_images is None:
             raise ValueError(
                 "If a readout plot is to be displayed image paths should be passed as a list."
                 + "The order of the images, should match the model output."

--- a/tests/test_dynapcnn/custom_jit_filters.py
+++ b/tests/test_dynapcnn/custom_jit_filters.py
@@ -1,0 +1,88 @@
+from typing import Optional
+
+import samna
+
+
+def majority_readout_filter(
+    feature_count: int,
+    default_feature: Optional[int] = None,
+    detection_threshold: int = 0,
+    threshold_low: int = 0,
+    threshold_high: Optional[int] = None,
+):
+    """
+    The default reaodut filter of samna's visualizer counts the total
+    number of events received per timestep to decide whether a detection
+    should be made or not.
+
+    The filter defined here allows for an additional `detection_threshold`
+    parameter which is compared to the number of spikes of the most
+    active class.
+    In other words, for a class to be detected, there needs to be
+    a minimum number of spikes for this class.
+    """
+
+    jit_src = f"""
+using InputT = speck2f::event::Spike;
+using OutputT = ui::Event;
+using ReadoutT = ui::Readout;
+
+template<typename Spike>
+class CustomMajorityReadout : public iris::FilterInterface<std::shared_ptr<const std::vector<Spike>>, std::shared_ptr<const std::vector<OutputT>>> {{
+private:
+    int featureCount = {feature_count};
+    uint32_t defaultFeature = {default_feature if default_feature is not None else feature_count};
+    int detectionThreshold = {detection_threshold};
+    int thresholdLow = {threshold_low};
+    int thresholdHigh = {threshold_high if threshold_high is not None else "std::numeric_limits<int>::max()"};
+
+public:
+    void apply() override
+    {{
+        while (const auto maybeSpikesPtr = this->receiveInput()) {{
+            if (0 == featureCount) {{
+                return;
+            }}
+
+            auto outputCollection = std::make_shared<std::vector<OutputT>>();
+            if ((*maybeSpikesPtr)->size() >= thresholdLow && (*maybeSpikesPtr)->size() <= thresholdHigh) {{
+                std::unordered_map<uint32_t, int> sum; // feature -> count
+                int maxCount = 0;
+                uint32_t maxCountFeature = 0;
+                int maxCountNum = 0;
+
+                for (const auto& spike : (**maybeSpikesPtr)) {{
+                    sum[spike.feature]++;
+                }}
+
+                for (const auto& [feature, count] : sum) {{
+                    if (feature >= featureCount) {{
+                        continue;
+                    }}
+
+                    if (count > maxCount) {{
+                        maxCount = count;
+                        maxCountFeature = feature;
+                        maxCountNum = 1;
+                    }}
+                    else if (count == maxCount) {{
+                        maxCountNum++;
+                    }}
+                }}
+
+                if (maxCount > detectionThreshold && 1 == maxCountNum) {{
+                    outputCollection->emplace_back(ReadoutT{{maxCountFeature}});
+                }}
+                else {{
+                    outputCollection->emplace_back(ReadoutT{{defaultFeature}});
+                }}
+            }}
+            else {{
+                outputCollection->emplace_back(ReadoutT{{defaultFeature}});
+            }}
+            this->forwardResult(std::move(outputCollection));
+        }}
+    }}
+}};
+"""
+    return samna.graph.JitFilter("CustomMajorityReadout", jit_src)

--- a/tests/test_dynapcnn/test_visualizer.py
+++ b/tests/test_dynapcnn/test_visualizer.py
@@ -1,5 +1,9 @@
+from itertools import product
+from typing import Callable, Union
+
 import pytest
 import samna
+from custom_jit_filters import majority_readout_filter as custom_filter
 from hw_utils import find_open_devices, is_any_samna_device_connected
 
 from sinabs.backend.dynapcnn.dynapcnn_visualizer import DynapcnnVisualizer
@@ -13,17 +17,31 @@ def X_available() -> bool:
     return p.returncode == 0
 
 
+vis_init_args = product(
+    (True, False),
+    (True, False),
+    ("JitMajorityReadout", custom_filter),
+)
+
+
 @pytest.mark.skipif(
     True,
     reason="A window needs to pop. Needs UI. Makes sense to check this test manually",
 )
-def test_visualizer_initialization():
+@pytest.mark.parametrize("spike_count_plot,readout_plot", vis_init_args)
+def test_visualizer_initialization(
+    spike_count_plot: bool, readout_plot: bool, readout_filter: Union[str, Callable]
+):
     dvs_shape = (128, 128)
     spike_collection_interval = 500
     visualizer_id = 3
 
     visualizer = DynapcnnVisualizer(
-        dvs_shape=dvs_shape, spike_collection_interval=spike_collection_interval
+        dvs_shape=dvs_shape,
+        spike_collection_interval=spike_collection_interval,
+        add_spike_count_plot=spike_count_plot,
+        add_readout_plot=spike_readout_plot,
+        readout_filter=readout_filter,
     )
     visualizer.create_visualizer_process(
         f"tcp://0.0.0.0:{visualizer.samna_visualizer_port}"

--- a/tests/test_dynapcnn/test_visualizer.py
+++ b/tests/test_dynapcnn/test_visualizer.py
@@ -28,9 +28,9 @@ vis_init_args = product(
     True,
     reason="A window needs to pop. Needs UI. Makes sense to check this test manually",
 )
-@pytest.mark.parametrize("spike_count_plot,readout_plot", vis_init_args)
+@pytest.mark.parametrize("spike_count_plot,readout_plot,readout_node", vis_init_args)
 def test_visualizer_initialization(
-    spike_count_plot: bool, readout_plot: bool, readout_filter: Union[str, Callable]
+    spike_count_plot: bool, readout_plot: bool, readout_node: Union[str, Callable]
 ):
     dvs_shape = (128, 128)
     spike_collection_interval = 500
@@ -40,8 +40,9 @@ def test_visualizer_initialization(
         dvs_shape=dvs_shape,
         spike_collection_interval=spike_collection_interval,
         add_spike_count_plot=spike_count_plot,
-        add_readout_plot=spike_readout_plot,
-        readout_filter=readout_filter,
+        add_readout_plot=readout_plot,
+        readout_node=readout_node,
+        readout_images=[],
     )
     visualizer.create_visualizer_process(
         f"tcp://0.0.0.0:{visualizer.samna_visualizer_port}"


### PR DESCRIPTION
## Checklist before requesting a review
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] I have performed a self-review of my code
- [x] Will this be part of a product update? If yes, please write one line about this on the CHANGELOG.md


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Minor feature upgrade: More flexibility in `DynapcnnVisualizer` class.

* **What is the current behavior?** (You can also link to an open issue here)
* Spike count plots are always included in the `DynapcnnVisualizer`, which can be annoying (see #238 )
* Readout predictions are based on a logic pre-defined in samna, which is sometimes not adequate to the task.

* **What is the new behavior (if this is a feature change)?**
* Spike count plots of the `DynapcnnVisualizer` are optional now.
* Custom JIT filters can be passed as readout nodes to the `DynapcnnVisualizer` class. This makes it possible to use custom logic for making predictions in the readout plot.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No, just added arguments. Existing code will keep working.

* **Other information**:
