### PR TITLE
259 readneuronvalue event has no timestamp attribute

### DIFF
--- a/sinabs/backend/dynapcnn/dynapcnn_network.py
+++ b/sinabs/backend/dynapcnn/dynapcnn_network.py
@@ -436,6 +436,11 @@ class DynapcnnNetwork(nn.Module):
             # Send input
             self.samna_input_buffer.write(x)
             received_evts = []
+
+            # Wait a minimum time to guarantee the events were played
+            time.sleep(1)
+
+            # Keep recording if more events are being registered
             while True:
                 prev_length = len(received_evts)
                 time.sleep(0.1)

--- a/sinabs/backend/dynapcnn/dynapcnn_network.py
+++ b/sinabs/backend/dynapcnn/dynapcnn_network.py
@@ -436,10 +436,6 @@ class DynapcnnNetwork(nn.Module):
             # Send input
             self.samna_input_buffer.write(x)
             received_evts = []
-            # Record at least until the last event has been replayed
-            min_duration = max(event.timestamp for event in x) * 1e-6
-            time.sleep(min_duration)
-            # Keep recording if more events are being registered
             while True:
                 prev_length = len(received_evts)
                 time.sleep(0.1)


### PR DESCRIPTION
## Checklist before requesting a review
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] I have performed a self-review of my code
- [ ] Will this be part of a product update? If yes, please write one line about this on the CHANGELOG.md


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix the calculation of minimum time the forward pass needs to wait.
It was taking into consideration the timestamp of events, however not all types of events have timestamps.


* **What is the current behavior?** (You can also link to an open issue here)
An error was being thrown when trying to access an inexistent attribute

* **What is the new behavior (if this is a feature change)?**
I am adding a fixed amount of time to wait before reading the output events

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

update their sinabs version only

* **Other information**:
