### PR TITLE
Construct Conv1d with input_shape=None argument

### DIFF
--- a/sinabs/nir.py
+++ b/sinabs/nir.py
@@ -184,6 +184,7 @@ def _extract_sinabs_module(module: torch.nn.Module) -> Optional[nir.NIRNode]:
             return nir.Affine(module.weight.detach(), module.bias.detach())
     elif isinstance(module, torch.nn.Conv1d):
         return nir.Conv1d(
+            input_shape=None,
             weight=module.weight.detach(),
             stride=module.stride,
             padding=module.padding,


### PR DESCRIPTION
This fixes an issue where transforming a Conv1D node results in error message TypeError: Conv1d.__init__() missing 1 required positional argument: 'input_shape'.

## Checklist before requesting a review
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [X] I have performed a self-review of my code
- [ ] Will this be part of a product update? If yes, please write one line about this on the CHANGELOG.md


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Provides a required argument to Conv1D node. 

* **What is the current behavior?** (You can also link to an open issue here)
https://github.com/synsense/sinabs/issues/303

* **What is the new behavior (if this is a feature change)?**
No more errors when transforming Conv1D nodes.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No, it fixes networks that use Conv1D.

* **Other information**:
