### PR TITLE
Fix tests when unexpected board is found and add speck2fdevkit to supported boards for tests

### DIFF
--- a/docs/about/release_notes.md
+++ b/docs/about/release_notes.md
@@ -1,5 +1,10 @@
 # Release notes
 
+## Unreleased
+
+* Fix tests crashing in case an unexpected board was found.
+* Fix tests that were not running for speck2fdevkit.
+
 ## v3.0.4 (08/09/2025)
 
 * Update sinabs code to be consistent with Python 3.12 and Numpy > 2.0.

--- a/tests/test_dynapcnn/hw_utils.py
+++ b/tests/test_dynapcnn/hw_utils.py
@@ -32,6 +32,7 @@ supported_device_types_for_testing = {
     "speck2e": "Speck2eTestBoard",
     "speck2edevkit": "Speck2eDevKit",
     "speck2fmodule": "Speck2fModuleDevKit",
+    "speck2fdevkit": "Speck2fDevKit",
 }
 
 
@@ -42,7 +43,8 @@ def find_open_devices():
     dev_infos = samna.device.get_all_devices()
     dev_dict = {}
     for dev_info in dev_infos:
-        dev_dict.update({reverse_dict[dev_info.device_type_name]: dev_info})
+        if dev_info.device_type_name in reverse_dict:
+            dev_dict.update({reverse_dict[dev_info.device_type_name]: dev_info})
     return dev_dict
 
 

--- a/tests/test_dynapcnn/test_single_neuron_hardware.py
+++ b/tests/test_dynapcnn/test_single_neuron_hardware.py
@@ -60,6 +60,7 @@ def test_deploy_dynapcnnnetwork():
                     "speck2e",
                     "speck2edevkit",
                     "speck2f",
+                    "speck2fdevkit",
                 ]
                 and core_idx < 2
             ):


### PR DESCRIPTION
Add verification in case the board connect is not supported for tests

## Checklist before requesting a review
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] I have performed a self-review of my code
- [x] Will this be part of a product update? If yes, please write one line about this on docs/about/release_notes.md


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

https://github.com/synsense/sinabs/issues/311
Also, speck2fdevkit was not on the list of supported boards for tests


* **What is the new behavior (if this is a feature change)?**

Tests should run for speck2fdevkit and in case an unsupported board is connected (such as XyloIMU) tests shouldnt crash, but instead not run for them.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
